### PR TITLE
POS3-19 In-memory full-duplex network connections

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -23,6 +23,7 @@ import (
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
+	configLibp2p "github.com/libp2p/go-libp2p/config"
 	"github.com/multiformats/go-multiaddr"
 )
 
@@ -46,6 +47,7 @@ type Config struct {
 	ID               string
 	MaxPeers         int64
 	MinInterval      int64
+	Transport        configLibp2p.TptC
 }
 
 func DefaultConfig() *Config {
@@ -79,6 +81,7 @@ func NewAgent(logger *log.Logger, config *Config) (*Agent, error) {
 	host, err := libp2p.New(
 		libp2p.ListenAddrs(listenAddr),
 		libp2p.AddrsFactory(addrsFactory),
+		libp2p.Transport(config.Transport),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create libp2p stack: %v", err)

--- a/transport/conn_manager.go
+++ b/transport/conn_manager.go
@@ -1,0 +1,87 @@
+package transport
+
+import (
+	"fmt"
+	"net"
+	"sync"
+)
+
+type ConnManagerFactory func() (net.Conn, net.Conn)
+
+type ConnManager interface {
+	Add(laddr, raddr string) (net.Conn, net.Conn)
+	Get(laddr, raddr string) (net.Conn, net.Conn)
+}
+
+type ConnManagerImpl struct {
+	lock        sync.RWMutex
+	connFactory ConnManagerFactory
+	connections map[string]map[string]net.Conn
+}
+
+func NewConnManagerImpl(connFactory ConnManagerFactory) *ConnManagerImpl {
+	return &ConnManagerImpl{
+		lock:        sync.RWMutex{},
+		connFactory: connFactory,
+		connections: make(map[string]map[string]net.Conn),
+	}
+}
+
+func NewConnManagerNetPipe() *ConnManagerImpl {
+	return NewConnManagerImpl(func() (net.Conn, net.Conn) {
+		return net.Pipe()
+	})
+}
+
+func NewConnManagerNetPipeAsync() *ConnManagerImpl {
+	return NewConnManagerImpl(func() (net.Conn, net.Conn) {
+		c1, c2 := net.Pipe()
+		return &asyncConnWrapper{c1}, &asyncConnWrapper{c2}
+	})
+}
+
+func (m *ConnManagerImpl) Add(laddr, raddr string) (net.Conn, net.Conn) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	connDialer, connListener := m.connFactory()
+	return m.addInLock(laddr, raddr, connDialer), m.addInLock(raddr, laddr, connListener)
+}
+
+func (m *ConnManagerImpl) Get(laddr, raddr string) (net.Conn, net.Conn) {
+	m.lock.RLock()
+	var conn1, conn2 net.Conn = nil, nil
+	if m.connections[laddr] != nil {
+		conn1 = m.connections[laddr][raddr]
+	}
+	if m.connections[raddr] != nil {
+		conn2 = m.connections[raddr][laddr]
+	}
+	m.lock.RUnlock()
+	if conn1 == nil || conn2 == nil {
+		conn1, conn2 = m.Add(laddr, raddr)
+	}
+	return conn1, conn2
+}
+
+func (m *ConnManagerImpl) addInLock(local, remote string, conn net.Conn) net.Conn {
+	if m.connections[local] == nil {
+		m.connections[local] = make(map[string]net.Conn)
+	}
+	m.connections[local][remote] = conn
+	return conn
+}
+
+type asyncConnWrapper struct {
+	net.Conn
+}
+
+// net.Pipe returns two net.Conn which communicate with each other in sync way. We must make this communication async
+func (c *asyncConnWrapper) Write(p []byte) (n int, err error) {
+	go func() {
+		_, err := c.Conn.Write(p)
+		if err != nil {
+			fmt.Printf("Error writing to pipe: %v\n", err)
+		}
+	}()
+	return len(p), nil
+}

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -1,0 +1,156 @@
+package transport
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+
+	"github.com/libp2p/go-libp2p-core/connmgr"
+	"github.com/libp2p/go-libp2p-core/host"
+	"github.com/libp2p/go-libp2p-core/peer"
+	"github.com/libp2p/go-libp2p-core/transport"
+	tptu "github.com/libp2p/go-libp2p-transport-upgrader"
+	"github.com/libp2p/go-libp2p/config"
+	ma "github.com/multiformats/go-multiaddr"
+	upstream "github.com/multiformats/go-multiaddr/net"
+)
+
+type NetworkQueryLatency interface {
+	CreateConn(baseConn net.Conn, laddr, raddr ma.Multiaddr) (net.Conn, error)
+}
+
+type Manager struct {
+	ConnManager         ConnManager
+	NetworkQueryLatency NetworkQueryLatency
+}
+
+func NewManager(connMngr ConnManager, networkQueryLatency NetworkQueryLatency) *Manager {
+	return &Manager{
+		ConnManager:         connMngr,
+		NetworkQueryLatency: networkQueryLatency,
+	}
+}
+
+func (m *Manager) NewConnection(conn net.Conn, laddr, raddr ma.Multiaddr) (*manetConn, error) {
+	conn, err := m.NetworkQueryLatency.CreateConn(conn, laddr, raddr)
+	if err != nil {
+		return nil, err
+	}
+	return &manetConn{conn, laddr, raddr}, nil
+}
+
+func (m *Manager) Transport() config.TptC {
+	return func(h host.Host, u *tptu.Upgrader, cg connmgr.ConnectionGater) (transport.Transport, error) {
+		tr := &Transport{
+			Upgrader: u,
+			Manager:  m,
+		}
+		return tr, nil
+	}
+}
+
+type Transport struct {
+	// need the upgrader to create the connection
+	Upgrader *tptu.Upgrader
+
+	// reference to the transport latency manager
+	Manager *Manager
+
+	// local address
+	laddr ma.Multiaddr
+
+	acceptCh chan connWithError
+	isClosed int32
+}
+
+func (t *Transport) newConnection(conn net.Conn, laddr, raddr ma.Multiaddr) (transport.CapableConn, error) {
+	manetConn, err := t.Manager.NewConnection(conn, laddr, raddr)
+	if err != nil {
+		return nil, err
+	}
+	return t.Upgrader.UpgradeInbound(context.Background(), t, manetConn)
+}
+
+func (t *Transport) Dial(ctx context.Context, raddr ma.Multiaddr, p peer.ID) (transport.CapableConn, error) {
+	if t.laddr == nil || raddr == nil {
+		panic("laddr and raddr must be specified")
+	}
+	conn1, conn2 := t.Manager.ConnManager.Get(t.laddr.String(), raddr.String())
+
+	// listener side
+	go func() {
+		resultConn, err := t.newConnection(conn2, raddr, t.laddr)
+		t.acceptCh <- connWithError{conn: resultConn, err: err}
+	}()
+
+	// dialer side
+	return t.newConnection(conn1, t.laddr, raddr)
+}
+
+func (t *Transport) CanDial(addr ma.Multiaddr) bool {
+	return true
+}
+
+func (t *Transport) Listen(laddr ma.Multiaddr) (transport.Listener, error) {
+	t.laddr = laddr
+	return t, nil
+}
+
+func (t *Transport) Protocols() []int {
+	// it is easier to override tcp than to figure out how to register a custom transport in multicodec
+	return []int{ma.P_TCP}
+}
+
+func (t *Transport) Proxy() bool {
+	return false
+}
+
+func (t *Transport) Accept() (transport.CapableConn, error) {
+	connWithError, hasMore := <-t.acceptCh
+	if !hasMore {
+		return nil, net.ErrClosed
+	}
+	if connWithError.err != nil {
+		return nil, connWithError.err
+	}
+	return connWithError.conn, nil
+}
+
+func (t *Transport) Close() error {
+	if atomic.CompareAndSwapInt32(&t.isClosed, 0, 1) {
+		close(t.acceptCh)
+	}
+	return nil
+}
+
+func (t *Transport) Addr() net.Addr {
+	v, _ := upstream.ToNetAddr(t.laddr)
+	return v
+}
+
+func (t *Transport) Multiaddr() ma.Multiaddr {
+	return t.laddr
+}
+
+// -- connection --
+
+type manetConn struct {
+	net.Conn
+
+	laddr ma.Multiaddr
+
+	raddr ma.Multiaddr
+}
+
+func (c *manetConn) LocalMultiaddr() ma.Multiaddr {
+	return c.laddr
+}
+
+func (c *manetConn) RemoteMultiaddr() ma.Multiaddr {
+	return c.raddr
+}
+
+type connWithError struct {
+	conn transport.CapableConn
+	err  error
+}


### PR DESCRIPTION
Allow `libp2p` servers to communicate with custom `net.Conn` implementation. Use `net.Pipe` for in memory data transfer

Note: tested on [repo](https://github.com/ferranbt/libp2p-gossip-bench)