### PR TITLE
POS3-76: Linear network topology

### DIFF
--- a/network/cluster.go
+++ b/network/cluster.go
@@ -258,6 +258,10 @@ func (c *Cluster) StartAgents(agentsNumber int, factory func(id int) (ClusterAge
 	return cntAgentsStarted, time.Since(startTime)
 }
 
+func (c *Cluster) ConnectAgents(topology Topology) {
+	topology.MakeConnections(c.agents)
+}
+
 func generateMsg(size int) []byte {
 	buf := make([]byte, size)
 	rand.Read(buf)

--- a/network/topology.go
+++ b/network/topology.go
@@ -1,0 +1,51 @@
+package network
+
+import (
+	"fmt"
+	"sort"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+type Topology interface {
+	MakeConnections(agents map[int]agentContainer)
+}
+
+type LinearTopology struct {
+	// number of nodes
+	NumNodes int
+}
+
+func (t LinearTopology) MakeConnections(agents map[int]agentContainer) {
+	keys := make([]int, 0)
+	for k := range agents {
+		keys = append(keys, k)
+	}
+	sort.Ints(keys)
+
+	startTime := time.Now()
+	wg := sync.WaitGroup{}
+	wg.Add(t.NumNodes)
+	cntAgentsConnected := int64(0)
+
+	for i, key := range keys {
+		if i <= len(keys)-1 {
+			go func(i int) {
+				defer wg.Done()
+
+				source := agents[key].agent
+				sink := agents[keys[i+1]].agent
+				err := source.Connect(sink)
+				if err != nil {
+					fmt.Println("Could not connect peers ", key, " ", keys[i+1], " ", err)
+				} else {
+					atomic.AddInt64(&cntAgentsConnected, 1)
+				}
+			}(i)
+		}
+	}
+
+	wg.Wait()
+	fmt.Printf("Connected %d agents. Ellapsed: %v\n", cntAgentsConnected, time.Since(startTime))
+}


### PR DESCRIPTION
Added an extensible setup to the existing Cluster creator. Using a new Topology type as a Specification pattern, trying not to violate the existing scenario as much as possible.

The Topology type should be responsible for creating desired Clusters. For now, size and connection directions are dictated with this new type but could be extended if necessary. 