### PR TITLE
POS3-115: Added HotStuff Messaging Mechanism

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -86,13 +86,6 @@ type packet struct {
 	IsUseful  bool
 }
 
-func NewAgent(logger *zap.Logger, config *GossipConfig) *GossipAgent {
-	return &GossipAgent{
-		Logger: logger,
-		Config: config,
-	}
-}
-
 func (a *GossipAgent) Listen(ipString string, port int) error {
 	listenAddr, err := ma.NewMultiaddr(fmt.Sprintf("/ip4/%s/tcp/%d", ipString, port))
 	if err != nil {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -100,20 +100,6 @@ func (c *GossipConfig) SetDefaults() {
 	c.PubsubQueueSize = 600
 }
 
-func DefaultGossipConfig() *GossipConfig {
-	return &GossipConfig{
-		GossipSubD:                 8,
-		GossipSubDlo:               6,
-		GossipSubDhi:               12,
-		GossipSubMcacheLen:         6,
-		GossipSubMcacheGossip:      3,
-		GossipSubSeenTTL:           550,
-		GossipSubFanoutTTL:         60000000000,
-		GossipSubHeartbeatInterval: 700 * time.Millisecond,
-		PubsubQueueSize:            600,
-	}
-}
-
 // gossipsub.
 // topic for pubsub
 const topicName = "Topic"

--- a/cluster/cluster.go
+++ b/cluster/cluster.go
@@ -147,7 +147,7 @@ func (c *Cluster) StartAgents(agentsNumber int, agentConfig agent.GossipConfig) 
 	)
 	added, failed, time := utils.MultiRoutineRunner(agentsNumber, itemsPerRoutine, maxRoutines, func(index int) error {
 		// configure agents
-		agent := agent.NewAgent(c.logger, &agentConfig)
+		agent := &agent.GossipAgent{Logger: c.logger, Config: &agentConfig}
 		city := c.latency.GetRandomCity()
 		_, err := c.AddAgent(agent, city, index < c.config.ValidatorCount)
 		return err

--- a/cluster/connections_list.go
+++ b/cluster/connections_list.go
@@ -1,8 +1,9 @@
-package agent
+package cluster
 
 import (
 	"time"
 
+	"github.com/maticnetwork/libp2p-gossip-bench/agent"
 	"github.com/maticnetwork/libp2p-gossip-bench/utils"
 )
 
@@ -13,15 +14,15 @@ const (
 
 // Holds list of all connection pairs (source and destination ClusterAgent)
 type connectionsList []struct {
-	src  Agent
-	dest Agent
+	src  agent.Agent
+	dest agent.Agent
 }
 
 // Add new connection pair to the list
-func (cl *connectionsList) Add(src, dest Agent) {
+func (cl *connectionsList) Add(src, dest agent.Agent) {
 	*cl = append(*cl, struct {
-		src  Agent
-		dest Agent
+		src  agent.Agent
+		dest agent.Agent
 	}{src: src, dest: dest})
 }
 

--- a/cluster/massage_loop.go
+++ b/cluster/massage_loop.go
@@ -1,0 +1,162 @@
+package cluster
+
+import (
+	"context"
+	"math/rand"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/maticnetwork/libp2p-gossip-bench/agent"
+)
+
+type Messaging interface {
+	Loop(ctx context.Context, agents []agentContainer) (publishedCnt, failedCnt int64)
+}
+
+type ConstantRateMessaging struct {
+	Rate        time.Duration // rate at which agents will fire messages
+	LogDuration time.Duration // period of time for which loggs are considered useful
+	MessageSize int           // size of sent message in bytes
+}
+
+func (c ConstantRateMessaging) Loop(ctx context.Context, agents []agentContainer) (int64, int64) {
+	var publishedCnt, failedCnt int64
+	var wg sync.WaitGroup
+	start := time.Now()
+
+	for _, a := range agents {
+		// start waiting for each agent we've started
+		wg.Add(1)
+		go func(a agent.Agent) {
+			tm := time.NewTicker(c.Rate)
+			defer func() {
+				tm.Stop()
+				defer wg.Done()
+			}()
+
+			for {
+				select {
+				case <-ctx.Done():
+					// kill or expiration signal received
+					return
+				case <-tm.C:
+					// log message, used for stats aggregation,
+					// should be logged only during specified benchmark log duration
+					err := a.SendMessage(c.MessageSize, shouldAggregate(start, c.LogDuration))
+					if err == nil {
+						atomic.AddInt64(&publishedCnt, 1)
+					} else {
+						atomic.AddInt64(&failedCnt, 1)
+					}
+				}
+			}
+		}(a.agent)
+	}
+
+	// wait for all started agents to shutdown
+	wg.Wait()
+
+	return publishedCnt, failedCnt
+}
+
+type HotstuffMessaging struct {
+	LogDuration time.Duration // period of time for which loggs are considered useful
+	MessageSize int           // size of sent message in bytes
+}
+
+func (h HotstuffMessaging) Loop(ctx context.Context, agents []agentContainer) (int64, int64) {
+	var publishedCnt, failedCnt int64
+	var wg sync.WaitGroup
+	start := time.Now()
+
+	// start ticker for leader and the rest of agents
+	tick := time.NewTicker(time.Second)
+	defer tick.Stop()
+	leaderChan, restChan := doubleTicker(tick.C)
+
+	// get a random index, for a random leader agent
+	rand.Seed(time.Now().UnixNano())
+	randIdx := rand.Intn(len(agents))
+	leader := agents[randIdx]
+	// get rest of the agents
+	rest := append(agents[:randIdx], agents[randIdx+1:]...)
+
+	// leader sends messages on odd seconds
+	wg.Add(1)
+	go func(a agent.Agent) {
+		defer wg.Done()
+		for {
+			select {
+			case <-ctx.Done():
+				// kill or expiration signal received
+				return
+			case <-leaderChan:
+				// log message, used for stats aggregation,
+				// should be logged only during specified benchmark log duration
+				err := a.SendMessage(h.MessageSize, shouldAggregate(start, h.LogDuration))
+				if err == nil {
+					atomic.AddInt64(&publishedCnt, 1)
+				} else {
+					atomic.AddInt64(&failedCnt, 1)
+				}
+			}
+		}
+
+	}(leader.agent)
+
+	// rest of the agents send their messages on even seconds
+	for _, a := range rest {
+		wg.Add(1)
+		go func(a agent.Agent) {
+			defer wg.Done()
+			for {
+				select {
+				case <-ctx.Done():
+					// kill or expiration signal received
+					return
+				case <-restChan:
+					err := a.SendMessage(h.MessageSize, shouldAggregate(start, h.LogDuration))
+					if err == nil {
+						atomic.AddInt64(&publishedCnt, 1)
+					} else {
+						atomic.AddInt64(&failedCnt, 1)
+					}
+				}
+			}
+		}(a.agent)
+	}
+
+	// wait for all started agents to shutdown
+	wg.Wait()
+
+	return publishedCnt, failedCnt
+}
+
+func onEvenSecond(t time.Time) bool {
+	return t.Second()%2 == 0
+}
+
+// doubleTicker is used to determine the rhythm of sent messages
+// channel for a leader agent receives messages on odd seconds
+// chanel for the rest of agents receives messages on even seconds
+func doubleTicker(c <-chan time.Time) (chan time.Time, chan time.Time) {
+	leadChan := make(chan time.Time)
+	restChan := make(chan time.Time)
+	go func() {
+		for t := range c {
+			if onEvenSecond(t) {
+				restChan <- t
+			} else {
+				leadChan <- t
+			}
+		}
+	}()
+	return leadChan, restChan
+}
+
+func shouldAggregate(start time.Time, duration time.Duration) bool {
+	msgTime := time.Now()
+	return msgTime.Before(start.Add(duration))
+
+}

--- a/cluster/message_loop.go
+++ b/cluster/message_loop.go
@@ -45,9 +45,9 @@ func (c ConstantRateMessaging) Loop(ctx context.Context, agents []agent.Agent) (
 					// should be logged only during specified benchmark log duration
 					err := a.SendMessage(c.MessageSize, shouldAggregate(start, c.LogDuration))
 					if err != nil {
-						atomic.AddInt64(&publishedCnt, 1)
-					} else {
 						atomic.AddInt64(&failedCnt, 1)
+					} else {
+						atomic.AddInt64(&publishedCnt, 1)
 					}
 				}
 			}
@@ -96,9 +96,9 @@ func (h HotstuffMessaging) Loop(ctx context.Context, agents []agent.Agent) (int6
 				// should be logged only during specified benchmark log duration
 				err := a.SendMessage(h.MessageSize, shouldAggregate(start, h.LogDuration))
 				if err != nil {
-					atomic.AddInt64(&publishedCnt, 1)
-				} else {
 					atomic.AddInt64(&failedCnt, 1)
+				} else {
+					atomic.AddInt64(&publishedCnt, 1)
 				}
 			}
 		}
@@ -118,9 +118,9 @@ func (h HotstuffMessaging) Loop(ctx context.Context, agents []agent.Agent) (int6
 				case <-restChan:
 					err := a.SendMessage(h.MessageSize, shouldAggregate(start, h.LogDuration))
 					if err != nil {
-						atomic.AddInt64(&publishedCnt, 1)
-					} else {
 						atomic.AddInt64(&failedCnt, 1)
+					} else {
+						atomic.AddInt64(&publishedCnt, 1)
 					}
 				}
 			}

--- a/cluster/random_topology.go
+++ b/cluster/random_topology.go
@@ -117,7 +117,7 @@ type rndToplogyPeer struct {
 	possibleConns []int
 }
 
-func newRndTopologyPeer(portID int, agent agent.Agent, agents map[int]agentContainer) *rndToplogyPeer {
+func newRndTopologyPeer(portID int, agent agent.Agent, agents []agentContainer) *rndToplogyPeer {
 	possible := make([]int, 0, len(agents)-1)
 	for _, agent := range agents {
 		if agent.port != portID {

--- a/cluster/random_topology.go
+++ b/cluster/random_topology.go
@@ -14,11 +14,11 @@ type RandomTopology struct {
 }
 
 // Creates random topology connections between peers
-func (t RandomTopology) MakeConnections(agents map[int]agentContainer) {
+func (t RandomTopology) MakeConnections(agents map[int]agent.Agent) {
 	connections := make(connectionsList, 0)
 
 	// create slice of agents and then populate random connection
-	possiblePeers := make([]agentContainer, 0, len(agents)) // list of all possible peers that can be choosen as source in one connection
+	possiblePeers := make([]agent.Agent, 0, len(agents)) // list of all possible peers that can be choosen as source in one connection
 	for _, value := range agents {
 		possiblePeers = append(possiblePeers, value)
 	}
@@ -29,15 +29,15 @@ func (t RandomTopology) MakeConnections(agents map[int]agentContainer) {
 	fmt.Printf("Connecting finished. Success: %d, failed: %d. Elapsed: %v\n", success, failed, elapsed)
 }
 
-func (t RandomTopology) populate(connections *connectionsList, peers []agentContainer) {
+func (t RandomTopology) populate(connections *connectionsList, peers []agent.Agent) {
 	count := t.Count
-	possiblePeers := make([]agentContainer, len(peers))  // this holds list of all possible peers in one iteration
+	possiblePeers := make([]agent.Agent, len(peers))     // this holds list of all possible peers in one iteration
 	peerMap := make(map[int]*rndToplogyPeer, len(peers)) // map portID -> *rndToplogyPeer
 
 	// init structures
 	copy(possiblePeers, peers)
-	for _, agentCont := range peers {
-		peerMap[agentCont.port] = newRndTopologyPeer(agentCont.port, agentCont.agent, peers)
+	for _, agent := range peers {
+		peerMap[agent.GetPort()] = newRndTopologyPeer(agent.GetPort(), agent, peers)
 	}
 
 	// create ring topology between nodes if specified
@@ -49,11 +49,11 @@ func (t RandomTopology) populate(connections *connectionsList, peers []agentCont
 		for i := 0; i < end && count > 0; i++ {
 			j := (i + 1) % len(possiblePeers)
 			src, dst := possiblePeers[i], possiblePeers[j]
-			peerMap[src.port].RemovePortId(dst.port)
-			peerMap[src.port].IncConnCount()
-			peerMap[dst.port].RemovePortId(src.port)
-			peerMap[dst.port].IncConnCount()
-			connections.Add(src.agent, dst.agent)
+			peerMap[src.GetPort()].RemovePortId(dst.GetPort())
+			peerMap[src.GetPort()].IncConnCount()
+			peerMap[dst.GetPort()].RemovePortId(src.GetPort())
+			peerMap[dst.GetPort()].IncConnCount()
+			connections.Add(src, dst)
 			count--
 		}
 	}
@@ -63,7 +63,7 @@ func (t RandomTopology) populate(connections *connectionsList, peers []agentCont
 		srcPeerIndex := rand.Intn(len(possiblePeers))
 
 		srcAgentCont := possiblePeers[srcPeerIndex]
-		srcPortID := srcAgentCont.port
+		srcPortID := srcAgentCont.GetPort()
 		srcPeer := peerMap[srcPortID]
 
 		dstPortID := srcPeer.PopRandomPortID()
@@ -96,12 +96,12 @@ func (t RandomTopology) populate(connections *connectionsList, peers []agentCont
 			newLength, oldLength := 0, len(possiblePeers)
 			for i := 0; i < oldLength; i++ {
 				agentCont := possiblePeers[i]
-				peer := peerMap[agentCont.port]
+				peer := peerMap[agentCont.GetPort()]
 				if peer.CanBeUsed(t.MaxPeers) {
 					possiblePeers[newLength] = agentCont
 					newLength++
 				} else {
-					delete(peerMap, agentCont.port)
+					delete(peerMap, agentCont.GetPort())
 				}
 			}
 			possiblePeers = possiblePeers[:newLength]
@@ -117,11 +117,11 @@ type rndToplogyPeer struct {
 	possibleConns []int
 }
 
-func newRndTopologyPeer(portID int, agent agent.Agent, agents []agentContainer) *rndToplogyPeer {
+func newRndTopologyPeer(portID int, agent agent.Agent, agents []agent.Agent) *rndToplogyPeer {
 	possible := make([]int, 0, len(agents)-1)
 	for _, agent := range agents {
-		if agent.port != portID {
-			possible = append(possible, agent.port)
+		if agent.GetPort() != portID {
+			possible = append(possible, agent.GetPort())
 		}
 	}
 	return &rndToplogyPeer{

--- a/cluster/random_topology.go
+++ b/cluster/random_topology.go
@@ -1,8 +1,10 @@
-package agent
+package cluster
 
 import (
 	"fmt"
 	"math/rand"
+
+	"github.com/maticnetwork/libp2p-gossip-bench/agent"
 )
 
 type RandomTopology struct {
@@ -111,11 +113,11 @@ func (t RandomTopology) populate(connections *connectionsList, peers []agentCont
 type rndToplogyPeer struct {
 	connCount     uint
 	portID        int
-	agent         Agent
+	agent         agent.Agent
 	possibleConns []int
 }
 
-func newRndTopologyPeer(portID int, agent Agent, agents []agentContainer) *rndToplogyPeer {
+func newRndTopologyPeer(portID int, agent agent.Agent, agents map[int]agentContainer) *rndToplogyPeer {
 	possible := make([]int, 0, len(agents)-1)
 	for _, agent := range agents {
 		if agent.port != portID {

--- a/cluster/supercluster_topology.go
+++ b/cluster/supercluster_topology.go
@@ -1,4 +1,4 @@
-package agent
+package cluster
 
 import (
 	"fmt"

--- a/cluster/supercluster_topology.go
+++ b/cluster/supercluster_topology.go
@@ -2,6 +2,8 @@ package cluster
 
 import (
 	"fmt"
+
+	"github.com/maticnetwork/libp2p-gossip-bench/agent"
 )
 
 // Each non validator is connected to at least one validator
@@ -11,12 +13,12 @@ type SuperClusterTopology struct {
 }
 
 // Creates supercluster topology connections between peers
-func (t SuperClusterTopology) MakeConnections(agents map[int]agentContainer) {
+func (t SuperClusterTopology) MakeConnections(agents map[int]agent.Agent) {
 	const connectionsNumber = 1000000
-	validators, nonValidators := make([]agentContainer, 0), make([]agentContainer, 0)
+	validators, nonValidators := make([]agent.Agent, 0), make([]agent.Agent, 0)
 	// create two list - one for validators and one for non validators
 	for _, ac := range agents {
-		if ac.isValidator {
+		if ac.IsValidator() {
 			validators = append(validators, ac)
 		} else {
 			nonValidators = append(nonValidators, ac)
@@ -44,7 +46,7 @@ func (t SuperClusterTopology) MakeConnections(agents map[int]agentContainer) {
 		connections = make(connectionsList, 0)
 		for i, ac := range nonValidators {
 			j := i % len(validators)
-			connections.Add(ac.agent, validators[j].agent)
+			connections.Add(ac, validators[j])
 		}
 		success, failed, elapsed = connections.ConnectAll()
 		fmt.Printf("Connecting non validators to validators finished. Success: %d, failed: %d. Elapsed: %v\n", success, failed, elapsed)

--- a/cluster/topology.go
+++ b/cluster/topology.go
@@ -1,4 +1,4 @@
-package agent
+package cluster
 
 import (
 	"fmt"

--- a/cluster/topology.go
+++ b/cluster/topology.go
@@ -6,15 +6,17 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/maticnetwork/libp2p-gossip-bench/agent"
 )
 
 type Topology interface {
-	MakeConnections(agents map[int]agentContainer)
+	MakeConnections(agents map[int]agent.Agent)
 }
 
 type LinearTopology struct{}
 
-func (t LinearTopology) MakeConnections(agents map[int]agentContainer) {
+func (t LinearTopology) MakeConnections(agents map[int]agent.Agent) {
 	keys := make([]int, 0)
 	for k := range agents {
 		keys = append(keys, k)
@@ -31,8 +33,8 @@ func (t LinearTopology) MakeConnections(agents map[int]agentContainer) {
 		go func(i int) {
 			defer wg.Done()
 
-			source := agents[keys[i]].agent
-			sink := agents[keys[i+1]].agent
+			source := agents[keys[i]]
+			sink := agents[keys[i+1]]
 			err := source.Connect(sink)
 			if err != nil {
 				fmt.Println("Could not connect peers ", keys[i], " ", keys[i+1], " ", err)

--- a/cmd/benchmark/commands/start_gossip_cmd.go
+++ b/cmd/benchmark/commands/start_gossip_cmd.go
@@ -106,9 +106,9 @@ func (fc *StartGossipCommand) Run(args []string) int {
 		topology = cluster.LinearTopology{}
 	case random:
 		topology = cluster.RandomTopology{
-			Connected: RandomTopologyConnected,
-			MaxPeers:  uint(fc.Params.peeringDegree),
-			Count:     uint(fc.Params.connectionCount),
+			CreateRing: RandomTopologyCreateRing,
+			MaxPeers:   uint(fc.Params.peeringDegree),
+			Count:      uint(fc.Params.connectionCount),
 		}
 	case superCluster:
 		topology = cluster.SuperClusterTopology{

--- a/cmd/benchmark/commands/start_gossip_cmd.go
+++ b/cmd/benchmark/commands/start_gossip_cmd.go
@@ -232,7 +232,8 @@ func StartGossipBench(ctx context.Context, params GossipParameters, topology clu
 	fmt.Println("Start adding agents: ", params.nodeCount)
 
 	// start agents in cluster
-	acfg := agent.DefaultGossipConfig()
+	acfg := &agent.GossipConfig{}
+	acfg.SetDefaults()
 	acfg.Transport = transportManager.Transport()
 	cluster.AddAgents(acfg, params.nodeCount)
 	agentsStarted, agentsFailed, timeAdded := cluster.StartAgents()

--- a/cmd/benchmark/commands/start_gossip_cmd.go
+++ b/cmd/benchmark/commands/start_gossip_cmd.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/maticnetwork/libp2p-gossip-bench/agent"
+	"github.com/maticnetwork/libp2p-gossip-bench/cluster"
 	lat "github.com/maticnetwork/libp2p-gossip-bench/latency"
 	"github.com/maticnetwork/libp2p-gossip-bench/network"
 	"github.com/mitchellh/cli"
@@ -94,19 +95,19 @@ func (fc *StartGossipCommand) Run(args []string) int {
 		fc.Params.connectionCount = -1
 	}
 
-	var topology agent.Topology
+	var topology cluster.Topology
 	switch fc.Params.topology {
 	case linear:
 		fc.Params.peeringDegree = 2
-		topology = agent.LinearTopology{}
+		topology = cluster.LinearTopology{}
 	case random:
-		topology = agent.RandomTopology{
-			CreateRing: RandomTopologyCreateRing,
-			MaxPeers:   uint(fc.Params.peeringDegree),
-			Count:      uint(fc.Params.connectionCount),
+		topology = cluster.RandomTopology{
+			Connected: RandomTopologyConnected,
+			MaxPeers:  uint(fc.Params.peeringDegree),
+			Count:     uint(fc.Params.connectionCount),
 		}
 	case superCluster:
-		topology = agent.SuperClusterTopology{
+		topology = cluster.SuperClusterTopology{
 			ValidatorPeering:    uint(fc.Params.peeringDegree),
 			NonValidatorPeering: uint(fc.Params.nonValidatorDegree),
 		}
@@ -158,7 +159,7 @@ func (fc *StartGossipCommand) NewFlagSet() *flag.FlagSet {
 	return flagSet
 }
 
-func StartGossipBench(ctx context.Context, params GossipParameters, topology agent.Topology) {
+func StartGossipBench(ctx context.Context, params GossipParameters, topology cluster.Topology) {
 	// remove file if exists
 	// logger configuration
 	cfg := zap.NewProductionConfig()
@@ -201,7 +202,7 @@ func StartGossipBench(ctx context.Context, params GossipParameters, topology age
 		zap.Int("connectionCount", params.connectionCount),
 	)
 	latencyData := lat.ReadLatencyDataFromJson()
-	cluster := agent.NewCluster(logger, latencyData, agent.ClusterConfig{
+	cluster := cluster.NewCluster(logger, latencyData, cluster.ClusterConfig{
 		Ip:             IpString,
 		StartingPort:   params.startingPort,
 		MsgSize:        params.messageSize,


### PR DESCRIPTION
Keep in mind: due to the golang nature in which goroutines consume channels, this PR is introduced with the bug described on Linear.
For the end goal to be achieved, we need all the rest of the validators to send messages at the same time for even seconds. This will hopefully be fixed with a new PR
