### PR TITLE
POS3-127: Fix for Messaging Synchronization

### DIFF
--- a/cluster/message_loop.go
+++ b/cluster/message_loop.go
@@ -28,8 +28,8 @@ func (c ConstantRateMessaging) Loop(ctx context.Context, agents []agent.Agent) (
 
 	// create time observable
 	timeSubject := observer.NewSubject(start)
-	// update subject with every tick
 	go func() {
+		// create a ticker for a defined messaging rate
 		tm := time.NewTicker(c.Rate)
 		defer tm.Stop()
 		for {
@@ -38,6 +38,7 @@ func (c ConstantRateMessaging) Loop(ctx context.Context, agents []agent.Agent) (
 				// kill or expiration signal received
 				return
 			case time := <-tm.C:
+				// update subject with new time from ticker
 				timeSubject.Update(time)
 			}
 		}
@@ -88,10 +89,23 @@ func (h HotstuffMessaging) Loop(ctx context.Context, agents []agent.Agent) (int6
 	var wg sync.WaitGroup
 	start := time.Now()
 
-	// start ticker for leader and the rest of agents
-	tick := time.NewTicker(time.Second)
-	defer tick.Stop()
-	leaderChan, restChan := doubleTicker(tick.C)
+	// create time observable
+	timeSubject := observer.NewSubject(start)
+	go func() {
+		// create a ticker for each second
+		tm := time.NewTicker(time.Second)
+		defer tm.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				// kill or expiration signal received
+				return
+			case time := <-tm.C:
+				// update subject with new time from ticker
+				timeSubject.Update(time)
+			}
+		}
+	}()
 
 	// get a random index, for a random leader agent
 	rand.Seed(time.Now().UnixNano())
@@ -104,19 +118,28 @@ func (h HotstuffMessaging) Loop(ctx context.Context, agents []agent.Agent) (int6
 	wg.Add(1)
 	go func(a agent.Agent) {
 		defer wg.Done()
+		stream := timeSubject.Observe()
+
 		for {
 			select {
 			case <-ctx.Done():
 				// kill or expiration signal received
 				return
-			case <-leaderChan:
-				// log message, used for stats aggregation,
-				// should be logged only during specified benchmark log duration
-				err := a.SendMessage(h.MessageSize, shouldAggregate(start, h.LogDuration))
-				if err != nil {
-					atomic.AddInt64(&failedCnt, 1)
-				} else {
-					atomic.AddInt64(&publishedCnt, 1)
+			case <-stream.Changes():
+				// advance to next value
+				stream.Next()
+				currentTime := stream.Value().(time.Time)
+
+				// check for odd second
+				if !onEvenSecond(currentTime) {
+					// log message, used for stats aggregation,
+					// should be logged only during specified benchmark log duration
+					err := a.SendMessage(h.MessageSize, shouldAggregate(start, h.LogDuration))
+					if err != nil {
+						atomic.AddInt64(&failedCnt, 1)
+					} else {
+						atomic.AddInt64(&publishedCnt, 1)
+					}
 				}
 			}
 		}
@@ -128,17 +151,28 @@ func (h HotstuffMessaging) Loop(ctx context.Context, agents []agent.Agent) (int6
 		wg.Add(1)
 		go func(a agent.Agent) {
 			defer wg.Done()
+			stream := timeSubject.Observe()
+
 			for {
 				select {
 				case <-ctx.Done():
 					// kill or expiration signal received
 					return
-				case <-restChan:
-					err := a.SendMessage(h.MessageSize, shouldAggregate(start, h.LogDuration))
-					if err != nil {
-						atomic.AddInt64(&failedCnt, 1)
-					} else {
-						atomic.AddInt64(&publishedCnt, 1)
+				case <-stream.Changes():
+					// advance to next value
+					stream.Next()
+					currentTime := stream.Value().(time.Time)
+
+					// check for even second
+					if onEvenSecond(currentTime) {
+						// log message, used for stats aggregation,
+						// should be logged only during specified benchmark log duration
+						err := a.SendMessage(h.MessageSize, shouldAggregate(start, h.LogDuration))
+						if err != nil {
+							atomic.AddInt64(&failedCnt, 1)
+						} else {
+							atomic.AddInt64(&publishedCnt, 1)
+						}
 					}
 				}
 			}
@@ -153,24 +187,6 @@ func (h HotstuffMessaging) Loop(ctx context.Context, agents []agent.Agent) (int6
 
 func onEvenSecond(t time.Time) bool {
 	return t.Second()%2 == 0
-}
-
-// doubleTicker is used to determine the rhythm of sent messages
-// channel for a leader agent receives messages on odd seconds
-// chanel for the rest of agents receives messages on even seconds
-func doubleTicker(c <-chan time.Time) (chan time.Time, chan time.Time) {
-	leadChan := make(chan time.Time)
-	restChan := make(chan time.Time)
-	go func() {
-		for t := range c {
-			if onEvenSecond(t) {
-				restChan <- t
-			} else {
-				leadChan <- t
-			}
-		}
-	}()
-	return leadChan, restChan
 }
 
 func shouldAggregate(start time.Time, duration time.Duration) bool {

--- a/observer/state.go
+++ b/observer/state.go
@@ -1,0 +1,26 @@
+package observer
+
+// The state object contains information about every event.
+// State objects are managed using a singly linked list structure.
+// Meaning that every state point to the next one.
+// For a newly raised event a new state object is appended to the
+// list and the channel of the previous state is closed.
+// This way all observers get notified that the previous state is stale.
+type state struct {
+	value interface{}
+	next  *state
+	done  chan struct{}
+}
+
+func newState(value interface{}) *state {
+	return &state{
+		value: value,
+		done:  make(chan struct{}),
+	}
+}
+
+func (s *state) update(value interface{}) *state {
+	s.next = newState(value)
+	close(s.done)
+	return s.next
+}

--- a/observer/state_test.go
+++ b/observer/state_test.go
@@ -1,0 +1,54 @@
+package observer
+
+import (
+	"testing"
+)
+
+func TestNew(t *testing.T) {
+	try := "yo"
+	state := newState(try)
+
+	if state.value != try {
+		t.Errorf("Expected %#v but go %#v\n", try, state.value)
+	}
+	if state.next != nil {
+		t.Errorf("Expected nil next but got %#v\n", state.next)
+	}
+
+	select {
+	case <-state.done:
+		t.Error("Expected that state should not be done\n")
+	default:
+	}
+}
+
+func TestUpdate(t *testing.T) {
+	try := "yo"
+	update := "po"
+
+	state := newState(try)
+	stateUpdated := state.update(update)
+
+	if state == stateUpdated {
+		t.Errorf("Expected states to be different\n")
+	}
+	if stateUpdated.value != update {
+		t.Errorf("Expected %#v but got %#v\n", state.value, stateUpdated.value)
+	}
+	if state.next == nil {
+		t.Errorf("Expected next to be nil but got %#v\n", state.next)
+	}
+
+	select {
+	case <-state.done:
+	default:
+		t.Errorf("Expected done to be closed\n")
+	}
+
+	if stateUpdated.value != update {
+		t.Errorf("Expected %#v but go %#v\n", try, stateUpdated.value)
+	}
+	if stateUpdated.next != nil {
+		t.Errorf("Expected nil next but got %#v\n", stateUpdated.next)
+	}
+}

--- a/observer/state_test.go
+++ b/observer/state_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestNew(t *testing.T) {
+func TestStateNew(t *testing.T) {
 	try := "yo"
 	state := newState(try)
 
@@ -22,7 +22,7 @@ func TestNew(t *testing.T) {
 	}
 }
 
-func TestUpdate(t *testing.T) {
+func TestStateUpdate(t *testing.T) {
 	try := "yo"
 	update := "po"
 
@@ -45,7 +45,7 @@ func TestUpdate(t *testing.T) {
 		t.Errorf("Expected done to be closed\n")
 	}
 
-	if stateUpdated.value != update {
+	if stateUpdated.value == update {
 		t.Errorf("Expected %#v but go %#v\n", try, stateUpdated.value)
 	}
 	if stateUpdated.next != nil {

--- a/observer/stream.go
+++ b/observer/stream.go
@@ -1,0 +1,59 @@
+package observer
+
+// Stream acts as a list of values that subject is being updated to.
+// On each subject update, that value is appended to the stream, in
+// exact order they happen.
+// The value is ditched once we move along the stream.
+// Stream is not goroutine safe.
+type Stream interface {
+	// Value for the current value in this stream
+	Value() interface{}
+
+	// Changes gives a channel that is closed when a new value is in the stream
+	Changes() chan struct{}
+
+	// Next pushes on this stream to the next state.
+	// Should be called only when Changes channel is closed,
+	// and used only when we want more controll
+	Next() interface{}
+
+	// HasNext tells whether stream has a new value or not
+	HasNext() bool
+
+	// WaitNext is blocked until Changes is closed,
+	// proceeds the stream to the next state and returns
+	// the current value
+	WaitNext() interface{}
+}
+
+type stream struct {
+	state *state
+}
+
+func (s *stream) Value() interface{} {
+	return s.state.value
+}
+
+func (s *stream) Changes() chan struct{} {
+	return s.state.done
+}
+
+func (s *stream) Next() interface{} {
+	s.state = s.state.next
+	return s.state.value
+}
+
+func (s *stream) HasNext() bool {
+	select {
+	case <-s.state.done:
+		return true
+	default:
+		return false
+	}
+}
+
+func (s *stream) WaitNext() interface{} {
+	<-s.state.done
+	s.state = s.state.next
+	return s.state.value
+}

--- a/observer/stream_test.go
+++ b/observer/stream_test.go
@@ -1,6 +1,9 @@
 package observer
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestStreamInitialValue(t *testing.T) {
 	try := "yo"
@@ -13,10 +16,11 @@ func TestStreamInitialValue(t *testing.T) {
 
 func TestStreamUpdate(t *testing.T) {
 	init := "yo"
-	update := "po"
 	state := newState(init)
-	updatedState := state.update(update)
 	stream := &stream{state: state}
+
+	update := "po"
+	updatedState := state.update(update)
 
 	if val := stream.Value(); val != init {
 		t.Errorf("Expected to get %#v but got %#v\n", init, val)
@@ -25,5 +29,69 @@ func TestStreamUpdate(t *testing.T) {
 	updatedState.update("ndoshta")
 	if val := stream.Value(); val != init {
 		t.Errorf("Expected to get %#v but got %#v\n", init, val)
+	}
+}
+
+func TestStreamNext(t *testing.T) {
+	init := "yo"
+	state := newState(init)
+	stream := &stream{state: state}
+
+	update := "po"
+	updatedState := state.update(update)
+
+	if val := stream.Next(); val != update {
+		t.Errorf("Expected to get %#v but got %#v\n", update, val)
+	}
+
+	newUpdate := "ndoshta"
+	updatedState.update(newUpdate)
+
+	if val := stream.Next(); val != newUpdate {
+		t.Errorf("Expected to get %#v but got %#v\n", update, val)
+	}
+}
+
+func TestStreamChanges(t *testing.T) {
+	init := "yo"
+	state := newState(init)
+	stream := &stream{state: state}
+
+	select {
+	case <-stream.Changes():
+		t.Errorf("Expecting nothing here")
+	default:
+	}
+
+	update := "po"
+	go func() {
+		time.Sleep(1 * time.Second)
+		state.update(update)
+	}()
+
+	select {
+	case <-stream.Changes():
+	// wait some period of time longer than 1 second needed for update
+	// if this happens 1st, we have a problem
+	case <-time.After(2 * time.Second):
+		t.Errorf("Shold be changes before this")
+	}
+
+	// state done channel is closed at this point
+	// we should still be able to receive from Changes
+	select {
+	case <-stream.Changes():
+	default:
+		t.Errorf("Should be changes here")
+	}
+
+	if val := stream.Next(); val != update {
+		t.Errorf("Expected to get %#v but got %#v\n", update, val)
+	}
+
+	select {
+	case <-stream.Changes():
+		t.Errorf("Should be no changes here")
+	default:
 	}
 }

--- a/observer/stream_test.go
+++ b/observer/stream_test.go
@@ -95,3 +95,41 @@ func TestStreamChanges(t *testing.T) {
 	default:
 	}
 }
+
+func TestStreamHasNext(t *testing.T) {
+	init := "yo"
+	state := newState(init)
+	stream := &stream{state: state}
+
+	if stream.HasNext() {
+		t.Errorf("Should be no changes")
+	}
+
+	update := "po"
+	state.update(update)
+	if !stream.HasNext() {
+		t.Errorf("Expecting changes here")
+	}
+
+	if val := stream.Next(); val != update {
+		t.Errorf("Expected to get %#v but got %#v\n", update, val)
+	}
+}
+
+func TestStreamWaitNext(t *testing.T) {
+	init := 10
+	state := newState(init)
+	stream := &stream{state: state}
+
+	start := 15
+	for i := start; i <= 100; i++ {
+		state = state.update(i)
+		if val := stream.WaitNext(); val != i {
+			t.Errorf("Expected to get %#v but got %#v\n", i, val)
+		}
+	}
+
+	if stream.HasNext() {
+		t.Errorf("Should be no changes")
+	}
+}

--- a/observer/stream_test.go
+++ b/observer/stream_test.go
@@ -1,0 +1,29 @@
+package observer
+
+import "testing"
+
+func TestStreamInitialValue(t *testing.T) {
+	try := "yo"
+	state := newState(try)
+	stream := &stream{state: state}
+	if val := stream.Value(); val == try {
+		t.Errorf("Expected to get %#v but got %#v\n", try, val)
+	}
+}
+
+func TestStreamUpdate(t *testing.T) {
+	init := "yo"
+	update := "po"
+	state := newState(init)
+	updatedState := state.update(update)
+	stream := &stream{state: state}
+
+	if val := stream.Value(); val != init {
+		t.Errorf("Expected to get %#v but got %#v\n", init, val)
+	}
+
+	updatedState.update("ndoshta")
+	if val := stream.Value(); val != init {
+		t.Errorf("Expected to get %#v but got %#v\n", init, val)
+	}
+}

--- a/observer/subject.go
+++ b/observer/subject.go
@@ -1,0 +1,34 @@
+package observer
+
+import "sync"
+
+// Subject is intented to be continuosly updated by one or more publishers.
+// Subject is fully goroutine safe.
+type Subject interface {
+	// Update sets a new value for this subject
+	Update(value interface{})
+
+	// Observe is used to watch over a Stream of values for this subject
+	Observe() Stream
+}
+
+type subject struct {
+	sync.RWMutex
+	state *state
+}
+
+func NewSubject(value interface{}) Subject {
+	return &subject{state: newState(value)}
+}
+
+func (s *subject) Update(value interface{}) {
+	s.Lock()
+	defer s.Unlock()
+	s.state = s.state.update(value)
+}
+
+func (s *subject) Observe() Stream {
+	s.RLock()
+	defer s.RUnlock()
+	return &stream{state: s.state}
+}

--- a/observer/subject.go
+++ b/observer/subject.go
@@ -5,6 +5,9 @@ import "sync"
 // Subject is intented to be continuosly updated by one or more publishers.
 // Subject is fully goroutine safe.
 type Subject interface {
+	// Value returns the current value that subject holds
+	Value() interface{}
+
 	// Update sets a new value for this subject
 	Update(value interface{})
 
@@ -19,6 +22,12 @@ type subject struct {
 
 func NewSubject(value interface{}) Subject {
 	return &subject{state: newState(value)}
+}
+
+func (s *subject) Value() interface{} {
+	s.RLock()
+	defer s.RUnlock()
+	return s.state.value
 }
 
 func (s *subject) Update(value interface{}) {

--- a/observer/subject_test.go
+++ b/observer/subject_test.go
@@ -1,0 +1,128 @@
+package observer
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+)
+
+func TestSubjectInitialValue(t *testing.T) {
+	init := "yo"
+	subject := NewSubject(init)
+
+	if val := subject.Value(); val != init {
+		t.Errorf("Expected to get %#v but got %#v\n", init, val)
+	}
+
+	stream := subject.Observe()
+	for i := 0; i <= 100; i++ {
+		if val := stream.Value(); val != init {
+			t.Errorf("Expected to get %#v but got %#v\n", init, val)
+		}
+	}
+}
+
+func TestSubjectInitialObserve(t *testing.T) {
+	init := "yo"
+	subject := NewSubject(init)
+
+	var prevStream Stream
+	for i := 0; i <= 100; i++ {
+		stream := subject.Observe()
+		if stream == prevStream {
+			t.Errorf("Should be different streams here")
+		}
+		if val := stream.Value(); val != init {
+			t.Errorf("Expected to get %#v but got %#v\n", init, val)
+		}
+		prevStream = stream
+	}
+}
+
+func TestSubjectAfterUpdate(t *testing.T) {
+	init := "yo"
+	subject := NewSubject(init)
+	if val := subject.Value(); val != init {
+		t.Errorf("Expected to get %#v but got %#v\n", init, val)
+	}
+
+	update := "po"
+	subject.Update(update)
+	if val := subject.Value(); val != update {
+		t.Errorf("Expected to get %#v but got %#v\n", update, val)
+	}
+
+	stream := subject.Observe()
+	if val := stream.Value(); val != update {
+		t.Errorf("Expected to get %#v but got %#v\n", update, val)
+	}
+}
+
+func TestSubjectMultipleReaders(t *testing.T) {
+	start := 1000
+	final := 2000
+	subject := NewSubject(start)
+
+	var errs []chan error
+	for i := 0; i < final-start; i++ {
+		err := make(chan error, 1)
+		errs = append(errs, err)
+		go testReadStream(subject.Observe(), start, final, err)
+	}
+
+	done := make(chan bool)
+	go func(subject Subject, start, final int, done chan bool) {
+		defer close(done)
+		for i := start + 1; i <= final; i++ {
+			subject.Update(i)
+		}
+	}(subject, start, final, done)
+
+	for _, errch := range errs {
+		if err := <-errch; err != nil {
+			t.Error(err)
+		}
+	}
+
+	<-done
+}
+
+func TestSubjectMultipleReadersWriters(t *testing.T) {
+	wg := &sync.WaitGroup{}
+	writer := func(subject Subject, times int) {
+		defer wg.Done()
+		for i := 0; i <= times; i++ {
+			val := subject.Value().(int)
+			subject.Update(val + 1)
+			subject.Observe()
+		}
+	}
+
+	init := 0
+	subject := NewSubject(init)
+	times := 1000
+	for i := 0; i < times; i++ {
+		wg.Add(1)
+		go writer(subject, times)
+	}
+	wg.Wait()
+}
+
+func testReadStream(s Stream, start, final int, err chan error) {
+	val := s.Value().(int)
+	if val != start {
+		err <- fmt.Errorf("Expected to get %#v but got %#v\n", start, val)
+		return
+	}
+
+	for i := start + 1; i <= final; i++ {
+		prev := val
+		val = s.WaitNext().(int)
+		expected := prev + 1
+		if val != expected {
+			err <- fmt.Errorf("Expected to get %#v but got %#v\n", expected, val)
+			return
+		}
+	}
+	close(err)
+}


### PR DESCRIPTION
Introduced a new observer package.
Because of memory and resource issues, didn't want to use multiple timers, channels, and goroutines to signal agents when to fire messages. Another reason, if we ignore memory problems, comes from the usual approach where we try to notify a set of goroutines using channels, to call each of the channels in the loop:
```
for _, c := range channels {
    c <- value
}
```
There are problems with this approach:

- The broadcaster could block every time if it happens that some channel is not ready to be written to
- If the broadcaster is blocked, the remaining channels will not be written to until the blocking channel is ready
- The more observers we have, the worse it will get [ O(n) ]

We could overcome this by creating one goroutine for each channel so the broadcaster doesn't block. This is resource-consuming, and we already had memory problems. This would especially get bad in our case, where we have events being raised frequently, with a considerable number of observers.